### PR TITLE
issueCommand changed from net.minecraft.server.MinecraftServer to net.minecraft.server.DedicatedServer

### DIFF
--- a/SimpleCronClone/src/org/bonsaimind/bukkitplugins/simplecronclone/CommandHelper.java
+++ b/SimpleCronClone/src/org/bonsaimind/bukkitplugins/simplecronclone/CommandHelper.java
@@ -7,9 +7,9 @@
 package org.bonsaimind.bukkitplugins.simplecronclone;
 
 import java.lang.reflect.Field;
-import net.minecraft.server.MinecraftServer;
 import org.bukkit.Server;
 import org.bukkit.craftbukkit.CraftServer;
+import net.minecraft.server.DedicatedServer;
 
 public class CommandHelper {
 
@@ -35,10 +35,10 @@ public class CommandHelper {
 			return;
 		}
 
-		MinecraftServer minecraftServer;
+		DedicatedServer minecraftServer;
 		try {
 			field.setAccessible(true);
-			minecraftServer = (MinecraftServer) field.get(server);
+			minecraftServer = (DedicatedServer) field.get(server);
 		} catch (IllegalArgumentException ex) {
 			System.err.println("CommandHelper: " + ex.getMessage());
 			return;
@@ -47,7 +47,7 @@ public class CommandHelper {
 			return;
 		}
 
-		if ((!minecraftServer.isStopped) && (MinecraftServer.isRunning(minecraftServer))) {
+		if ((!minecraftServer.isStopped()) && (minecraftServer.isRunning())) {
 			minecraftServer.issueCommand(command, minecraftServer);
 		}
 	}


### PR DESCRIPTION
this is due to the minecraft 1.3.1 update, 
[1.2.5R4](https://github.com/Bukkit/CraftBukkit-Bleeding/blob/d95aee59d6e455bdfc7724c3400a5bca1d2a6a5e/src/main/java/net/minecraft/server/MinecraftServer.java#L589)

[1.3.1R0.1](https://github.com/Bukkit/CraftBukkit-Bleeding/blob/master/src/main/java/net/minecraft/server/DedicatedServer.java#L234)

also use the public method instead of the private boolean for `!minecraftServer.isStopped()`
