### PR TITLE
fix for the new craftbukkit net.minecraft namespace stuff

### DIFF
--- a/SimpleCronClone/src/org/bonsaimind/bukkitplugins/simplecronclone/CommandHelper.java
+++ b/SimpleCronClone/src/org/bonsaimind/bukkitplugins/simplecronclone/CommandHelper.java
@@ -8,8 +8,8 @@ package org.bonsaimind.bukkitplugins.simplecronclone;
 
 import java.lang.reflect.Field;
 import org.bukkit.Server;
-import org.bukkit.craftbukkit.CraftServer;
-import net.minecraft.server.DedicatedServer;
+import org.bukkit.craftbukkit.v1_4_6.CraftServer;
+import net.minecraft.server.v1_4_6.DedicatedServer;
 
 public class CommandHelper {
 


### PR DESCRIPTION
bukkit/craftbukkit changed so that anything touching non-bukkit code that is in net.minecraft or org.bukkit.craftbukkit has to hook into a specific version. this is a quick recompile to make it work, there are better ways but i do not have the time to figure that out. may be a week or two. would be best if someone else with more java experience did this.
