### PR TITLE
 removed need to touch craftbukkit internals to execute console commands

### DIFF
--- a/SimpleCronClone/src/org/bonsaimind/bukkitplugins/simplecronclone/CommandHelper.java
+++ b/SimpleCronClone/src/org/bonsaimind/bukkitplugins/simplecronclone/CommandHelper.java
@@ -18,37 +18,6 @@ public class CommandHelper {
 			System.err.println("CommandHelper: server is null...is the plugin broken?");
 			return;
 		}
-		/*
-		if (!(server instanceof CraftServer)) {
-			System.err.println("CommandHelper: server is not a server...is the plugin broken?");
-			return;
-		} */
-/*		
-		Field field;
-		try {
-			field = CraftServer.class.getDeclaredField("console");
-		} catch (NoSuchFieldException ex) {
-			System.err.println("CommandHelper: " + ex.getMessage());
-			return;
-		} catch (SecurityException ex) {
-			System.err.println("CommandHelper: " + ex.getMessage());
-			return;
-		}
-
-		DedicatedServer minecraftServer;
-		try {
-			field.setAccessible(true);
-			minecraftServer = (DedicatedServer) field.get(server);
-		} catch (IllegalArgumentException ex) {
-			System.err.println("CommandHelper: " + ex.getMessage());
-			return;
-		} catch (IllegalAccessException ex) {
-			System.err.println("CommandHelper: " + ex.getMessage());
-			return;
-		}
-*/
-		//if ((!server.isStopped()) && (server.isRunning())) {
 			server.dispatchCommand(server.getConsoleSender(), command);
-		//}
 	}
 }


### PR DESCRIPTION
seems that the old way was over a year and a half old, about time to update it :D 

Old method originated before there was a way via bukkitAPI to send console commands, now that the old method is breaking all the time, (and that I now know it exists...) use the new API (that is months old...)
